### PR TITLE
Add support for Chromium browser

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,43 +7,26 @@ on:
     branches:
       - '**'
 jobs:
-  test-chrome:
-    runs-on: ubuntu-latest
+  test:
+    name: Test using ${{ matrix.label }}
+    runs-on: ${{ matrix.platform }}
+    strategy:
+      matrix:
+        include:
+        - { label: 'Chrome', browser: 'chrome', platform: 'ubuntu-latest' }
+        - { label: 'Chromium', browser: 'chromium', platform: 'ubuntu-latest' }
+        - { label: 'ARM Chromium', browser: 'chromium', platform: 'ubuntu-22.04-arm' }
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
       - name: Build Docker image
         run: |
-          docker build -f docker/Dockerfile.chrome -t urlapi .
+          docker build -f docker/Dockerfile.${{ matrix.browser }} -t urlapi .
 
-      - name: Run tests inside Docker container
+      - name: Who am I
         run: |
-          docker run --rm -t -e ALLOW_HTTP=true urlapi bash -c 'npm install && npm run test'
-
-  test-chromium:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build Docker image
-        run: |
-          docker build -f docker/Dockerfile.chromium -t urlapi .
-
-      - name: Run tests inside Docker container
-        run: |
-          docker run --rm -t -e ALLOW_HTTP=true urlapi bash -c 'npm install && npm run test'
-
-  test-chromium-arm:
-    runs-on: ubuntu-22.04-arm
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Build Docker image
-        run: |
-          docker build -f docker/Dockerfile.chromium -t urlapi .
+          docker run --rm -t -e ALLOW_HTTP=true urlapi bash -c 'echo "Using arch $(arch), browser at ${BROWSER_EXECUTABLE_PATH}" && $BROWSER_EXECUTABLE_PATH --version'
 
       - name: Run tests inside Docker container
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - '**'
 jobs:
-  test:
+  test-chrome:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -15,7 +15,35 @@ jobs:
 
       - name: Build Docker image
         run: |
-          docker build -t urlapi .
+          docker build -f docker/Dockerfile.chrome -t urlapi .
+
+      - name: Run tests inside Docker container
+        run: |
+          docker run --rm -t -e ALLOW_HTTP=true urlapi bash -c 'npm install && npm run test'
+
+  test-chromium:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -f docker/Dockerfile.chromium -t urlapi .
+
+      - name: Run tests inside Docker container
+        run: |
+          docker run --rm -t -e ALLOW_HTTP=true urlapi bash -c 'npm install && npm run test'
+
+  test-chromium-arm:
+    runs-on: ubuntu-22.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: |
+          docker build -f docker/Dockerfile.chromium -t urlapi .
 
       - name: Run tests inside Docker container
         run: |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
+[![Tests](https://github.com/andrepiske/webrender-api/actions/workflows/test.yml/badge.svg)](https://github.com/andrepiske/webrender-api/actions/workflows/test.yml)
 
-This is a hard fork from the url-to-pdf-api repository at commit [2fa83fd9f88613b76ba452fe25830e98d844f3b0](https://github.com/alvarcarto/url-to-pdf-api/commit/2fa83fd9f88613b76ba452fe25830e98d844f3b0).
+Note: it seems the original author has given up the repository (I'm very thankful for all the effort put into this so far!), so I'm forking and doing a few updates, adding CI and providing Dockerfiles.
+
+The API is backwards compatible.
+
+Here is the original README.md contents:
 
 <br><br><br><br>
 # URL to PDF Microservice

--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -27,7 +27,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     node --version && npm --version && yarn --version
 
 # Install google chrome
-ENV GOOGLE_CHROME_VERSION=138.0.7204.49-1
+ARG GOOGLE_CHROME_VERSION=138.0.7204.49-1
 RUN set -eux ; \
     apt-get update -y \
     && curl -Lo /tmp/google-chrome.deb "https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_${GOOGLE_CHROME_VERSION}_amd64.deb" \

--- a/docker/Dockerfile.chromium
+++ b/docker/Dockerfile.chromium
@@ -1,0 +1,75 @@
+FROM debian:bookworm-slim
+
+ENV LANG=C.UTF-8
+
+RUN apt-get update -y && apt-get install -y --no-install-recommends \
+      ca-certificates \
+      curl \
+      # gnupg is required to install Node
+      gnupg \
+    ; \
+    rm -rf /var/lib/apt/lists/*
+
+ENV NODE_VERSION=22.17.0
+ENV NODE_MAJOR=22
+RUN mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODE_MAJOR}.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "Package: nodejs" | tee /etc/apt/preferences.d/nodejs > /dev/null && \
+    echo "Pin: origin deb.nodesource.com" | tee -a /etc/apt/preferences.d/nodejs > /dev/null && \
+    echo "Pin-Priority: 600" | tee -a /etc/apt/preferences.d/nodejs > /dev/null && \
+    apt-get update -y && \
+    apt-get install -y --no-install-recommends nodejs=${NODE_VERSION}-1nodesource1 && \
+    rm -rf /var/lib/apt/lists/* ; \
+    corepack enable && \
+    npm i -g npm && \
+    # smoke tests
+    node --version && npm --version && yarn --version
+
+# Install Chromium
+# ARG CHROMIUM_VERSION="latest"
+ARG CHROMIUM_VERSION="138.0.7204.92"
+ARG CHROMIUM_DEB_SITE="http://deb.debian.org/debian"
+RUN echo "deb ${CHROMIUM_DEB_SITE}/ sid main" >> /etc/apt/sources.list \
+  && curl -fsL https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg \
+  && curl -fsL https://ftp-master.debian.org/keys/archive-key-12-security.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-security-keyring.gpg \
+  && apt-get update -qqy \
+  && if [ "${CHROMIUM_VERSION}" = "latest" ]; \
+      then apt-get -y --no-install-recommends install chromium-common chromium chromium-l10n ; \
+     else mkdir -p /tmp/chromium \
+      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-common_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium-common.deb \
+      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium.deb \
+      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-l10n_${CHROMIUM_VERSION}-1_all.deb -o /tmp/chromium/chromium-l10n.deb \
+      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-driver_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium-driver.deb \
+      && apt-get -qqyf install /tmp/chromium/chromium-common.deb /tmp/chromium/chromium.deb /tmp/chromium/chromium-l10n.deb /tmp/chromium/chromium-driver.deb \
+      && rm -rf /tmp/chromium; \
+    fi \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+ENV BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PORT=9000
+
+RUN set -eux ; \
+  groupadd --gid 1000 node &&  \
+  useradd --uid 1000 --gid node --shell /bin/bash --create-home node
+
+ENV HOME=/home/node
+ARG APP_HOME=/home/node/srv
+WORKDIR $APP_HOME
+
+RUN chown -R node:node $APP_HOME
+
+USER node
+
+# Uncomment when iterating locally to move faster:
+#   COPY --chown=1000:1000 package.json ./
+#   COPY --chown=1000:1000 package-lock.json ./
+#   RUN npm install --omit=dev
+
+COPY --chown=1000:1000 . ./
+
+RUN npm install --omit=dev
+
+EXPOSE $PORT
+CMD ["node", "."]


### PR DESCRIPTION
I'm splitting the `Dockerfile` into two dockerfiles under the `docker/` path. One with Chrome and another with Chromium. Chrome only has releases for amd64 for Linux. So to be able to deploy this in ARM, Chromium needs to be used. Yeah there are other browsers, but that'd be a lot of more effort to support them all.