### PR TITLE
Fix Dockerfile for Chromium install, add docker-compose with envs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ jspm_packages
 
 # Yarn Integrity file
 .yarn-integrity
+*.pdf

--- a/docker/Dockerfile.chromium
+++ b/docker/Dockerfile.chromium
@@ -26,25 +26,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     # smoke tests
     node --version && npm --version && yarn --version
 
-# Install Chromium
-# ARG CHROMIUM_VERSION="latest"
-ARG CHROMIUM_VERSION="140.0.7339.185"
-ARG CHROMIUM_DEB_SITE="http://deb.debian.org/debian"
-RUN echo "deb ${CHROMIUM_DEB_SITE}/ sid main" >> /etc/apt/sources.list \
-  && curl -fsL https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg \
-  && curl -fsL https://ftp-master.debian.org/keys/archive-key-12-security.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-security-keyring.gpg \
-  && apt-get update -qqy \
-  && if [ "${CHROMIUM_VERSION}" = "latest" ]; \
-      then apt-get -y --no-install-recommends install chromium-common chromium chromium-l10n ; \
-     else mkdir -p /tmp/chromium \
-      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-common_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium-common.deb \
-      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium.deb \
-      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-l10n_${CHROMIUM_VERSION}-1_all.deb -o /tmp/chromium/chromium-l10n.deb \
-      && curl -fsL ${CHROMIUM_DEB_SITE}/pool/main/c/chromium/chromium-driver_${CHROMIUM_VERSION}-1_$(dpkg --print-architecture).deb -o /tmp/chromium/chromium-driver.deb \
-      && apt-get -qqyf install /tmp/chromium/chromium-common.deb /tmp/chromium/chromium.deb /tmp/chromium/chromium-l10n.deb /tmp/chromium/chromium-driver.deb \
-      && rm -rf /tmp/chromium; \
-    fi \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+RUN apt-get update && apt-get install -y --no-install-recommends chromium && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 ENV BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
 ENV PUPPETEER_SKIP_DOWNLOAD=true

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  webrender:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile.chromium
+    environment:
+      - LANG=C.UTF-8
+      - NODE_VERSION=22.17.0
+      - NODE_MAJOR=22
+      - CHROMIUM_VERSION=140.0.7339.185
+      - CHROMIUM_DEB_SITE=http://deb.debian.org/debian
+      - BROWSER_EXECUTABLE_PATH=/usr/bin/chromium
+      - PUPPETEER_SKIP_DOWNLOAD=true
+      - PORT=9000
+      - ALLOW_URLS=host:en.wikipedia.org
+      - ALLOW_HTTP=true
+    ports:
+      - "9000:9000"
+    working_dir: /home/node/srv
+    user: "1000:1000"
+    command: ["node", "."]
+    restart: unless-stopped


### PR DESCRIPTION
### Description

- Fixed the Dockerfile to simplify and ensure reliable Chromium installation.
- Added a `docker-compose.yml` example for local development and testing.
- Configured environment variables to allow PDF rendering only for the host `en.wikipedia.org` (for demonstration/testing purposes, not for production).
- Enabled HTTP requests for local testing convenience.
- Updated `.gitignore` to exclude generated PDF files.

### Notes

- The `ALLOW_URLS=host:en.wikipedia.org` setting is intended only as an example for testing. For production, you should restrict or configure allowed hosts as needed for your use case.
- The service was tested locally using the Wikipedia PDF endpoint and worked as expected.