### PR TITLE
Address CVE-2026-25547

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -246,9 +246,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "glob": ">=10.5.0",
     "js-yaml": ">=4.1.1",
     "qs": ">=6.14.1",
-    "diff": ">=8.0.3"
+    "diff": ">=8.0.3",
+    "@isaacs/brace-expansion": ">=5.0.1"
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.6",


### PR DESCRIPTION
Update https://www.npmjs.com/package/@isaacs/brace-expansion to address [CVE-2026-25547](https://github.com/advisories/GHSA-7h2j-956f-4vf2) (https://nvd.nist.gov/vuln/detail/CVE-2026-25547)